### PR TITLE
fix a case of stuck VM on delete

### DIFF
--- a/action/delete_vm.go
+++ b/action/delete_vm.go
@@ -82,6 +82,7 @@ func (a CPI) stopVmById(vmId string) error {
 	a.client.AsyncTimeout(a.config.CloudStack.Timeout.StopVm)
 
 	p := a.client.VirtualMachine.NewStopVirtualMachineParams(vmId)
+	p.SetForced(true)
 	_, err := a.client.VirtualMachine.StopVirtualMachine(p)
 	return err
 }

--- a/bin/build
+++ b/bin/build
@@ -2,6 +2,12 @@
 
 set -e
 
-bin=$(dirname $0)
+bin=$(dirname "$0")
 
-go build -o $bin/cpi github.com/orange-cloudfoundry/bosh-cpi-cloudstack/main
+export CGO_ENABLED=0
+
+go build \
+	-a -ldflags "-s -w" \
+	-gcflags="all=-trimpath=$GOPATH" \
+	-o "${bin:-.}/cpi" \
+	github.com/orange-cloudfoundry/bosh-cpi-cloudstack/main


### PR DESCRIPTION
In some cases, calls to [`destroyVirtualMachine`](https://cloudstack.apache.org/api/apidocs-4.11/apis/destroyVirtualMachine.html) fail;
this case is described at least in apache/cloudstack/issues/3054.

This patch will send a [force stop](https://cloudstack.apache.org/api/apidocs-4.11/apis/stopVirtualMachine.html) prior issuing the VM deletion order.