### PR TITLE
Fix unrecoverable error on missing disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Bosh-cpi-cloudstack
 
-Complete rewrite in golang of [current cpi cloudstack](https://github.com/cloudfoundry-community/bosh-cloudstack-cpi-core/).
+Complete rewrite in golang of the [current CloudStack CPI](https://github.com/cloudfoundry-community/bosh-cloudstack-cpi-core/).
 
-This new CPI remove boilerplate as:
-- **Webdav**: This was used to be able to register stemcell as template in cloudstack.
-We now use template upload provided natively by cloudstack (see: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=39620237)
+This new CPI remove boilerplate as such as:
+- **Webdav**: This was used to be able to register stemcell as template in CloudStack.
+We now use template upload provided natively by CloudStack (see: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=39620237)
 - **Registry**: There is no [registry](https://bosh.io/docs/bosh-components/#registry) implementation in this CPI.
 We target to use registry provided by bosh.
 - **Web Server**: This new CPI is not anymore a webserver as the previous CPI. This is fully compliant with bosh RPC mechanism to call CPI.

--- a/action/attach_disk.go
+++ b/action/attach_disk.go
@@ -2,10 +2,11 @@ package action
 
 import (
 	"fmt"
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
-	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 	"strings"
+
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 
 func (a CPI) AttachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) error {
@@ -75,7 +76,7 @@ func (a CPI) AttachDiskBase(vmCID apiv1.VMCID, diskCID apiv1.DiskCID, isV2 bool)
 func (a CPI) registerDisk(name string, vmCID apiv1.VMCID, diskCID apiv1.DiskCID, hint apiv1.DiskHint) error {
 	// we skip registry registering if disk is an ephemeral one
 	if strings.HasPrefix(name, config.EphemeralDiskPrefix) {
-		a.logger.Debug("attach_disk", "skip registering epehemeral disks ...")
+		a.logger.Debug("attach_disk", "skip registering ephemeral disks ...")
 		return nil
 	}
 	nvSvc := a.regFactory.Create(vmCID)

--- a/action/calculate_vm_cloud_properties.go
+++ b/action/calculate_vm_cloud_properties.go
@@ -2,11 +2,12 @@ package action
 
 import (
 	"fmt"
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
-	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"sort"
 	"strings"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
 func (a CPI) CalculateVMCloudProperties(res apiv1.VMResources) (apiv1.VMCloudProps, error) {
@@ -97,7 +98,6 @@ func (a CPI) findServiceOffering(ram, cpu int) (string, error) {
 
 	return finalOffers[0].Name, nil
 }
-
 
 func (a CPI) filterDiskOffering(offers []*cloudstack.DiskOffering) []*cloudstack.DiskOffering {
 	if len(a.config.CloudStack.CalculateCloudProp.DiskTags) == 0 &&

--- a/action/calculate_vm_cloud_properties.go
+++ b/action/calculate_vm_cloud_properties.go
@@ -26,8 +26,10 @@ func (a CPI) CalculateVMCloudProperties(res apiv1.VMResources) (apiv1.VMCloudPro
 	}), nil
 }
 
+// findEphemeralDiskOffering find a disk offering by disk size, expressed in megabytes
 func (a CPI) findEphemeralDiskOffering(diskSize int) (string, error) {
-	diskSize = int(diskSize / 1024)
+	// convert to GiB
+	diskSize /= 1024
 	resp, err := a.client.DiskOffering.ListDiskOfferings(a.client.DiskOffering.NewListDiskOfferingsParams())
 	if err != nil {
 		return "", err

--- a/action/common.go
+++ b/action/common.go
@@ -233,7 +233,10 @@ func (a CPI) findOrCreateAffinityGroup(name, aType string) (string, error) {
 	if af != nil && af.Type != aType {
 		p := a.client.AffinityGroup.NewDeleteAffinityGroupParams()
 		p.SetName(name)
-		a.client.AffinityGroup.DeleteAffinityGroup(p)
+		resp, err := a.client.AffinityGroup.DeleteAffinityGroup(p)
+		if err != nil {
+			a.logger.Warn("delete_affinity_group", "error while deleting security group: %s (%v)", name, resp)
+		}
 	}
 	p := a.client.AffinityGroup.NewCreateAffinityGroupParams(name, aType)
 	resp, err := a.client.AffinityGroup.CreateAffinityGroup(p)
@@ -271,5 +274,4 @@ func retryable(timeout time.Duration, cmd func() error, checkRetry func(err erro
 		}
 		time.Sleep(timer)
 	}
-	return err
 }

--- a/action/common.go
+++ b/action/common.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"time"
 
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/util"
-	"github.com/apache/cloudstack-go/v2/cloudstack"
 )
 
 func (a CPI) setMetadata(tagType config.Tags, cid string, meta util.MetaMarshal) error {

--- a/action/create_disk.go
+++ b/action/create_disk.go
@@ -70,6 +70,9 @@ func (a CPI) createEphemeralDisk(size int, diskProps DiskCloudProperties, cid st
 	return apiv1.NewDiskCID(diskName), nil
 }
 
+// createVolume request the creation of a new storage volume
+//
+// The size is expressed in megabytes.
 func (a CPI) createVolume(diskName string, size int, diskOfferName string, cid string) (*cloudstack.CreateVolumeResponse, error) {
 	a.client.AsyncTimeout(a.config.CloudStack.Timeout.CreateVolume)
 
@@ -94,7 +97,8 @@ func (a CPI) createVolume(diskName string, size int, diskOfferName string, cid s
 	p.SetDiskofferingid(offer.Id)
 
 	if offer.Iscustomized {
-		size = int(size / 1024)
+		// CloudStack volume sizes are expressed in gigabytes
+		size /= 1024
 		p.SetSize(int64(size))
 	}
 

--- a/action/create_disk.go
+++ b/action/create_disk.go
@@ -2,10 +2,11 @@ package action
 
 import (
 	"fmt"
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
-	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
+
 	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 	"github.com/satori/go.uuid"
 )
 
@@ -62,7 +63,7 @@ func (a CPI) createEphemeralDisk(size int, diskProps DiskCloudProperties, cid st
 		})
 		err := a.setMetadata(config.Volume, diskName, &meta)
 		if err != nil {
-			a.logger.Warn("create_ephemeral_disk", "Error occured when setting metadata on ephemeral disk %s: %s", diskName, err.Error())
+			a.logger.Warn("create_ephemeral_disk", "Error occurred when setting metadata on ephemeral disk %s: %s", diskName, err.Error())
 		}
 	}
 

--- a/action/create_stemcell.go
+++ b/action/create_stemcell.go
@@ -4,13 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
-	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
-	"github.com/apache/cloudstack-go/v2/cloudstack"
-	"github.com/satori/go.uuid"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -18,6 +12,12 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/apache/cloudstack-go/v2/cloudstack"
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
+	"github.com/satori/go.uuid"
 )
 
 // CreateStemcell - Create CS template from given stemcell
@@ -25,7 +25,7 @@ import (
 // 1. read cloud-properties
 // 2. generate template name from random id
 // 3. request CS an upload token
-// 4. push image to CS recieved endpoint
+// 4. push image to CS received endpoint
 func (a CPI) CreateStemcell(imagePath string, cp apiv1.StemcellCloudProps) (apiv1.StemcellCID, error) {
 	csProp := CloudStackCloudProperties{}
 	err := cp.As(&csProp)
@@ -65,7 +65,7 @@ func (a CPI) CreateStemcell(imagePath string, cp apiv1.StemcellCloudProps) (apiv
 		return apiv1.StemcellCID{}, bosherr.WrapErrorf(err, "[create_stemcell]")
 	}
 	a.logger.Info("create_stemcell", "Finished Uploading stemcell %s ...", name)
-	a.logger.Debug("create_stemcell", "create_stemcell succes : template %s (%s)", uploadP.Id, name)
+	a.logger.Debug("create_stemcell", "create_stemcell success: template %s (%s)", uploadP.Id, name)
 	return apiv1.NewStemcellCID(name), nil
 }
 
@@ -144,7 +144,7 @@ func (a CPI) createUploadRequest(
 	r, _ := http.NewRequest("POST", postURL, body)
 
 	// manually replace header since:
-	//  - CS is case sensitive on header names
+	//  - CS is case-sensitive on header names
 	//  - golang concert header names into UpperCamelCase
 	r.Header = map[string][]string{
 		"X-signature":  []string{signature},
@@ -174,7 +174,7 @@ func (a CPI) performUpload(request *http.Request) error {
 	}
 
 	if uploadRes.StatusCode != 200 {
-		bodyBytes, _ := ioutil.ReadAll(uploadRes.Body)
+		bodyBytes, _ := io.ReadAll(uploadRes.Body)
 		return fmt.Errorf("unexpected response while uploading stemcell: %s", string(bodyBytes))
 	}
 

--- a/action/create_vm.go
+++ b/action/create_vm.go
@@ -214,7 +214,10 @@ func (a CPI) CreateBase(p CreateArgs, isV2 bool) (apiv1.VMCID, apiv1.Networks, e
 				"Cannot attach ephemeral disk when creating vm"),
 			resp.Id,
 			func() {
-				a.DeleteDisk(diskCid)
+				err := a.DeleteDisk(diskCid)
+				if err != nil {
+					a.logger.Warn("delete_disk", "unable to delete disk: %s", diskCid)
+				}
 			},
 		)
 	}

--- a/action/create_vm.go
+++ b/action/create_vm.go
@@ -236,11 +236,11 @@ func (a CPI) applyMacToNetworks(resp *cloudstack.DeployVirtualMachineResponse, b
 }
 
 func (a CPI) parseCIDR(cidr string) (string, string, error) {
-	addr, net, err := net.ParseCIDR(cidr)
+	addr, ipNet, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return "", "", err
 	}
-	mask := fmt.Sprintf("%d.%d.%d.%d", net.Mask[0], net.Mask[1], net.Mask[2], net.Mask[3])
+	mask := fmt.Sprintf("%d.%d.%d.%d", ipNet.Mask[0], ipNet.Mask[1], ipNet.Mask[2], ipNet.Mask[3])
 	return addr.String(), mask, nil
 }
 
@@ -414,7 +414,7 @@ type NetworkElem struct {
 // 1. create sortable structure
 // 2. sort network, default first, the by name
 // 3. create CS network list
-//    - vip network not given to cloudstack
+//   - vip network not given to cloudstack
 func (a CPI) generateNetworksMap(networks apiv1.Networks, zoneID string) (*cloudstack.Network, []map[string]string, error) {
 	result := make([]map[string]string, 0)
 	var defaultNetwork *cloudstack.Network

--- a/action/delete_disk.go
+++ b/action/delete_disk.go
@@ -1,9 +1,10 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"fmt"
 )
 
 func (a CPI) DeleteDisk(cid apiv1.DiskCID) error {

--- a/action/delete_stemcell.go
+++ b/action/delete_stemcell.go
@@ -1,8 +1,8 @@
 package action
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
 // DeleteStemcell - Delete CS template matching given stemcell name

--- a/action/delete_vm.go
+++ b/action/delete_vm.go
@@ -68,7 +68,10 @@ func (a CPI) DeleteVM(cid apiv1.VMCID) error {
 
 	a.logger.Info("delete_vm", "Removing all ephemeral disks for vm %s ...", cid.AsString())
 	for _, diskId := range ephemDisks {
-		a.client.Volume.DeleteVolume(a.client.Volume.NewDeleteVolumeParams(diskId))
+		_, err := a.client.Volume.DeleteVolume(a.client.Volume.NewDeleteVolumeParams(diskId))
+		if err != nil {
+			a.logger.Warn("delete_disk", "unable to delete volume: %s", diskId)
+		}
 	}
 	a.logger.Info("delete_vm", "Finished removing all ephemeral disks for vm %s ...", cid.AsString())
 
@@ -129,7 +132,10 @@ func (a CPI) liberateVIPs(vmId string) error {
 	}
 	for _, rule := range respRules.IpForwardingRules {
 		ruleDelParams := a.client.NAT.NewDeleteIpForwardingRuleParams(rule.Id)
-		a.client.NAT.DeleteIpForwardingRule(ruleDelParams)
+		_, err := a.client.NAT.DeleteIpForwardingRule(ruleDelParams)
+		if err != nil {
+			a.logger.Warn("DeleteIpForwardingRule", "IP forwarding deletion failed for rule: %v", rule)
+		}
 	}
 
 	listPubIpParams := a.client.Address.NewListPublicIpAddressesParams()
@@ -144,7 +150,10 @@ func (a CPI) liberateVIPs(vmId string) error {
 			continue
 		}
 		disableParams := a.client.NAT.NewDisableStaticNatParams(pubIp.Id)
-		a.client.NAT.DisableStaticNat(disableParams)
+		_, err := a.client.NAT.DisableStaticNat(disableParams)
+		if err != nil {
+			a.logger.Warn("DisableStaticNat", "static NAT disable failed for: %v", pubIp)
+		}
 	}
 	return nil
 }

--- a/action/delete_vm.go
+++ b/action/delete_vm.go
@@ -1,10 +1,11 @@
 package action
 
 import (
+	"strings"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
-	"strings"
 )
 
 func (a CPI) DeleteVM(cid apiv1.VMCID) error {

--- a/action/detach_disk.go
+++ b/action/detach_disk.go
@@ -1,10 +1,11 @@
 package action
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
-	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 	"strings"
+
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 
 func (a CPI) DetachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) error {

--- a/action/detach_disk.go
+++ b/action/detach_disk.go
@@ -21,7 +21,8 @@ func (a CPI) DetachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) error {
 	}
 
 	if len(volumes) == 0 {
-		return bosherr.Errorf("No volume found with name %s", diskCID.AsString())
+		a.logger.Warn("detach_disk", "No volume found with name %s", diskCID.AsString())
+		return nil
 	}
 
 	volume := volumes[0]

--- a/action/detach_disk.go
+++ b/action/detach_disk.go
@@ -49,7 +49,10 @@ func (a CPI) DetachDisk(vmCID apiv1.VMCID, diskCID apiv1.DiskCID) error {
 		err = a.unregisterDisk(vmCID, diskCID)
 		if err != nil {
 			p := a.client.Volume.NewAttachVolumeParams(volume.Id, volume.Virtualmachineid)
-			a.client.Volume.AttachVolume(p)
+			resp, attachError := a.client.Volume.AttachVolume(p)
+			if attachError != nil {
+				a.logger.Error("attach_disk", "unable to re-attach volume: %s to %s (%v)", volume.Id, volume.Virtualmachineid, resp)
+			}
 			return err
 		}
 	}

--- a/action/env.go
+++ b/action/env.go
@@ -1,8 +1,9 @@
 package action
 
 import (
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	"encoding/json"
+
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 )
 
 type VMEnv struct {

--- a/action/factory.go
+++ b/action/factory.go
@@ -1,11 +1,11 @@
 package action
 
 import (
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"github.com/apache/cloudstack-go/v2/cloudstack"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/reg"
-	"github.com/apache/cloudstack-go/v2/cloudstack"
 )
 
 type Factory struct {

--- a/action/get_disks.go
+++ b/action/get_disks.go
@@ -1,10 +1,11 @@
 package action
 
 import (
+	"strings"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
-	"strings"
 )
 
 func (a CPI) GetDisks(cid apiv1.VMCID) ([]apiv1.DiskCID, error) {

--- a/action/has_disk.go
+++ b/action/has_disk.go
@@ -1,9 +1,10 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"fmt"
 )
 
 func (a CPI) HasDisk(cid apiv1.DiskCID) (bool, error) {

--- a/action/has_vm.go
+++ b/action/has_vm.go
@@ -1,9 +1,10 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"fmt"
 )
 
 func (a CPI) HasVM(cid apiv1.VMCID) (bool, error) {

--- a/action/metadata_service.go
+++ b/action/metadata_service.go
@@ -4,8 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 

--- a/action/periodic_clean_disk.go
+++ b/action/periodic_clean_disk.go
@@ -1,8 +1,9 @@
 package action
 
 import (
-	"time"
 	"strings"
+	"time"
+
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 
@@ -17,7 +18,7 @@ func (a CPI) PeriodicCleanDisk() {
 
 func (a CPI) cleanDisk() {
 	defer time.Sleep(time.Duration(a.config.CloudStack.IntervalCleanDisk) * time.Minute)
-	a.logger.Info("periodic_clean_disk", "Start cleaning emphemeral disks ...")
+	a.logger.Info("periodic_clean_disk", "Start cleaning ephemeral disks ...")
 	p := a.client.Volume.NewListVolumesParams()
 	p.SetTags(map[string]string{
 		"director": a.config.CloudStack.DirectorName,
@@ -25,7 +26,7 @@ func (a CPI) cleanDisk() {
 
 	resp, err := a.client.Volume.ListVolumes(p)
 	if err != nil {
-		a.logger.Warn("periodic_clean_disk", "Error occured when finding volumes: %s", err.Error())
+		a.logger.Warn("periodic_clean_disk", "Error occurred when finding volumes: %s", err.Error())
 		return
 	}
 
@@ -38,7 +39,7 @@ func (a CPI) cleanDisk() {
 
 		t, err := time.Parse(time.RFC3339, vol.Created)
 		if err != nil {
-			a.logger.Warn("periodic_clean_disk", "Error occured when parsing create time for volume %s: %s", vol.Name, err.Error())
+			a.logger.Warn("periodic_clean_disk", "Error occurred when parsing create time for volume %s: %s", vol.Name, err.Error())
 			return
 		}
 
@@ -50,11 +51,11 @@ func (a CPI) cleanDisk() {
 		delParams := a.client.Volume.NewDeleteVolumeParams(vol.Id)
 		_, err = a.client.Volume.DeleteVolume(delParams)
 		if err != nil {
-			a.logger.Warn("periodic_clean_disk", "Error occured when deleting volume %s: %s", vol.Name, err.Error())
+			a.logger.Warn("periodic_clean_disk", "Error occurred when deleting volume %s: %s", vol.Name, err.Error())
 			return
 		}
 		a.logger.Info("periodic_clean_disk", "Finished deleting volume %s .", vol.Name)
 	}
-	a.logger.Info("periodic_clean_disk", "Finished cleaning emphemeral disks.")
+	a.logger.Info("periodic_clean_disk", "Finished cleaning ephemeral disks.")
 
 }

--- a/action/resize_disk.go
+++ b/action/resize_disk.go
@@ -1,9 +1,10 @@
 package action
 
 import (
+	"fmt"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"fmt"
 )
 
 func (a CPI) ResizeDisk(cid apiv1.DiskCID, size int) error {
@@ -22,7 +23,7 @@ func (a CPI) ResizeDisk(cid apiv1.DiskCID, size int) error {
 	if offer.Disksize > int64(size/1024) {
 		return NewNotImplementedError(
 			fmt.Errorf(
-				"Disk size requested is smaller than current disk size (current: %dGb, asked: %dGb)",
+				"Disk size requested is smaller than current disk size (current: %dGB, asked: %dGB)",
 				offer.Disksize,
 				int64(size/1024),
 			))

--- a/action/set_disk_metadata.go
+++ b/action/set_disk_metadata.go
@@ -1,8 +1,8 @@
 package action
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 

--- a/action/set_vm_metadata.go
+++ b/action/set_vm_metadata.go
@@ -1,8 +1,8 @@
 package action
 
 import (
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 

--- a/action/snapshot_disk.go
+++ b/action/snapshot_disk.go
@@ -36,7 +36,10 @@ func (a CPI) SnapshotDisk(diskCID apiv1.DiskCID, meta apiv1.DiskMeta) (apiv1.Sna
 	}
 	a.logger.Info("resize_disk", "Finished snapshotting disk %s .", diskCID.AsString())
 
-	a.setMetadata(config.Snapshot, resp.Id, &meta)
+	err = a.setMetadata(config.Snapshot, resp.Id, &meta)
+	if err != nil {
+		a.logger.Warn("set_metadata", "an error occurred while setting metadata to: %s = %v", resp.Id, &meta)
+	}
 
 	return apiv1.NewSnapshotCID(resp.Id), nil
 }

--- a/action/snapshot_disk.go
+++ b/action/snapshot_disk.go
@@ -1,9 +1,10 @@
 package action
 
 import (
+	"strings"
+
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
-	"strings"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 
@@ -27,13 +28,13 @@ func (a CPI) SnapshotDisk(diskCID apiv1.DiskCID, meta apiv1.DiskMeta) (apiv1.Sna
 		return apiv1.SnapshotCID{}, bosherr.Errorf("Volume found with name %s is not a persistent disk", diskCID.AsString())
 	}
 
-	a.logger.Info("resize_disk", "Snapshoting disk %s ...", diskCID.AsString())
+	a.logger.Info("resize_disk", "Snapshotting disk %s ...", diskCID.AsString())
 	p := a.client.Snapshot.NewCreateSnapshotParams(volume.Id)
 	resp, err := a.client.Snapshot.CreateSnapshot(p)
 	if err != nil {
 		return apiv1.SnapshotCID{}, bosherr.WrapErrorf(err, "Could not create snapshot for disk %s", diskCID.AsString())
 	}
-	a.logger.Info("resize_disk", "Finished snapshooting disk %s .", diskCID.AsString())
+	a.logger.Info("resize_disk", "Finished snapshotting disk %s .", diskCID.AsString())
 
 	a.setMetadata(config.Snapshot, resp.Id, &meta)
 

--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
-	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
 type RegistryOptions struct {
@@ -105,7 +105,7 @@ type StemcellConfig struct {
 
 func NewConfigFromPath(path string) (Config, error) {
 	config := defaultConfig()
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return config, bosherr.WrapErrorf(err, "Reading config '%s'", path)
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,8 +3,8 @@ package config
 import (
 	"errors"
 
-	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -14,8 +14,7 @@ var validConfig = Config{
 	Actions:    validActionsOptions,
 }
 
-var validWardenConfig = CloudStackConfig{
-}
+var validWardenConfig = CloudStackConfig{}
 
 var validActionsOptions = FactoryOpts{
 	Agent: apiv1.AgentOptions{

--- a/main/main.go
+++ b/main/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"os"
 
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/cloudfoundry/bosh-cpi-go/rpc"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
 	bwcaction "github.com/orange-cloudfoundry/bosh-cpi-cloudstack/action"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"

--- a/reg/factory.go
+++ b/reg/factory.go
@@ -1,8 +1,8 @@
 package reg
 
 import (
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 

--- a/reg/registry_agent_env_service.go
+++ b/reg/registry_agent_env_service.go
@@ -4,12 +4,12 @@ import (
 	gobytes "bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
+	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	"github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
 )
 
@@ -58,7 +58,7 @@ func (s registryAgentEnvService) Fetch() (apiv1.AgentEnv, error) {
 		return nil, bosherr.Errorf("Received non-200 status code when contacting registry: '%d'", httpResponse.StatusCode)
 	}
 
-	httpBody, err := ioutil.ReadAll(httpResponse.Body)
+	httpBody, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, bosherr.WrapErrorf(err, "Reading response from registry endpoint '%s'", s.endpoint)
 	}

--- a/reg/registry_agent_env_service_test.go
+++ b/reg/registry_agent_env_service_test.go
@@ -4,17 +4,17 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/orange-cloudfoundry/bosh-cpi-cloudstack/reg"
 	. "github.com/orange-cloudfoundry/bosh-cpi-cloudstack/config"
+	. "github.com/orange-cloudfoundry/bosh-cpi-cloudstack/reg"
 )
 
 var _ = Describe("RegistryAgentEnvService", func() {
@@ -175,7 +175,7 @@ func (s *registryServer) instanceHandler(w http.ResponseWriter, req *http.Reques
 	}
 
 	if req.Method == "PUT" {
-		reqBody, _ := ioutil.ReadAll(req.Body)
+		reqBody, _ := io.ReadAll(req.Body)
 		s.InstanceSettings = reqBody
 		w.WriteHeader(http.StatusOK)
 		return


### PR DESCRIPTION
When the CPI attempt to detach a volume which is no longer present in the IaaS, it irrecoverably fail.

This patch ignore the missing disk without blocking other operations.